### PR TITLE
Update required cortex-m-rt version to include 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["arm", "cortex-m", "stm32", "stm32l4", "svd2rust"]
 license = "MIT OR Apache-2.0"
 name = "stm32l4x6"
 repository = "https://github.com/brandonedens/stm32l4x6"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 bare-metal = "0.2.0"
@@ -16,7 +16,7 @@ vcell = "0.1.0"
 
 [dependencies.cortex-m-rt]
 optional = true
-version = "0.5.0"
+version = ">=0.5.0, <0.7.0"
 
 [features]
 rt = ["cortex-m-rt/device"]


### PR DESCRIPTION
cortex-m-rt 0.6 is compatible with bindings generated by sbd2rust so we should follow suit and update requirements for its version to allow 0.6